### PR TITLE
Fix: do not modify shape bounding box in place

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,7 +40,8 @@ var computeMeshBoundingBoxes = _fp.flow(_fp.forEach(function (value, key) {
  *         `THREE.Vector3`.
  */
 var computeCenters = _fp.mapValues(function (bbox_i) {
-    return bbox_i.max.sub(bbox_i.min).multiplyScalar(.5).add(bbox_i.min);
+    return (bbox_i.clone().max.sub(bbox_i.min).multiplyScalar(.5)
+            .add(bbox_i.min));
 });
 
 


### PR DESCRIPTION
Prior to this commit, the `computeCenters` function unintentionally
modified the shape bounding box while computing the center position.  As
of this commit, the bounding box is cloned first to avoid the issue.
